### PR TITLE
add hound override

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -274,5 +274,8 @@ Style/EmptyLinesAroundBlockBody:
 Style/UnneededPercentQ:
   Enabled: false
 
+Style/StringLiterals:
+  Enabled: false
+
 Metrics/AbcSize:
   Enabled: false


### PR DESCRIPTION
The single vs. double quotes has been coming up repeatedly and are not being updated before merge, so we'd like to disable the alerts.
